### PR TITLE
Increase MAXL from 256 to _POSIX2_LINE_MAX (2056)

### DIFF
--- a/src/adddef.h
+++ b/src/adddef.h
@@ -26,6 +26,7 @@
 
 #define UPTR	void*
 
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -39,7 +40,7 @@ typedef int (*CMPF)(const UPTR, const UPTR);
 #define ERROR	(-1)
 #define OK	0
 #define ABORT	INT_MIN
-#define MAXL	256
+#define MAXL	_POSIX2_LINE_MAX
 #define NAMSIZ	MAXL
 #define ON	1
 #define OFF	0


### PR DESCRIPTION
While trying to create a bioconda recipe for spaln, I ran into an issue concerning long pathnames generated during the conda build process that cause an error during `make install`:

```
make install
...
./makmdm /tmp/miniconda/conda-bld/spaln_1514737890207/_b_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pla/table

  7.6862  5.1057  4.2546  5.1269  2.0279  4.1061  6.1820  7.4714  2.2983  5.2569
  9.1111  5.9498  2.3414  4.0530  5.0532  6.8225  5.8518  1.4336  3.2303  6.6374
make: *** [install] Abort trap: 
```

This appears to be due to the long pathname exceeding the hard-coded limit in spaln of 256. Bumping up MAXL (which appears to be used for maximum line lengths in files as well) to the POSIX standard _POSIX2_LINE_MAX (defined in limits.h as 2056) resolved the issue.