### PR TITLE
Update Makefile.in:  harden binaries with RELRO mitigations

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -6,14 +6,14 @@ table_dir = /usr/local/bin
 alndbs_dir = /db/seqdb
 CXX  = g++
 #CXX  = clang++
-CFLAGS = -O3 -march=native
+CFLAGS += -O3 -march=native
 RANLIB = ranlib
 LD  = g++
 AR = ar ru
 DEL = rm -f
 DEFLT = -DM_THREAD=1
 
-CXX := $(CXX) $(CFLAGS) $(DEFLT)
+CXX := $(CXX) $(CFLAGS) $(CPPFLAGS) $(DEFLT)
 
 .SUFFIXES: .o .cc .h .sh
 
@@ -88,13 +88,13 @@ ls:
 	ls $(SRC) $(HDR)
 
 spaln:	spaln.cc blksrc.o $(SLIB)
-	$(CXX) -o $@ spaln.cc blksrc.o $(SLIB) $(ILIB)
+	$(CXX) -o $@ spaln.cc blksrc.o $(SLIB) $(ILIB) $(LDFLAGS)
 sortgrcd:	sortgrcd.cc $(SLIB)
-	$(CXX) -o $@ sortgrcd.cc $(SLIB) $(ILIB)
-makdbs: makdbs.cc dbs.h seq.h bitpat.h $(SLIB)
-	$(CXX) -o $@ makdbs.cc $(SLIB) $(ILIB)
+	$(CXX) -o $@ sortgrcd.cc $(SLIB) $(ILIB) $(LDFLAGS)
+makdbs: makdbs.cc dbs.h seq.h bitpat.h $(SLIB) 
+	$(CXX) -o $@ makdbs.cc $(SLIB) $(ILIB) $(LDFLAGS)
 makmdm: makmdm.cc mdm.h $(CLIB)
-	$(CXX) -o $@ makmdm.cc $(CLIB) $(ILIB)
+	$(CXX) -o $@ makmdm.cc $(CLIB) $(ILIB) $(LDFLAGS)
 
 dvn:	dvn.cc autocomp.h $(ULIB)
 	$(CXX) -o $@ dvn.cc $(ULIB) $(ILIB)


### PR DESCRIPTION
first of all i would like to thank you for adding support for adding support for staged install as suggested in issue #61.
 
binaries produced by current Makefile lack common security mitigation such as [RELRO](https://wiki.archlinux.org/title/Arch_package_guidelines/Security#RELRO) as recommended by major linux distribution including debian

```log
spaln W: ELF file ('usr/bin/makdbs') lacks FULL RELRO, check LDFLAGS.
spaln W: ELF file ('usr/bin/makmdm') lacks FULL RELRO, check LDFLAGS.
spaln W: ELF file ('usr/bin/sortgrcd') lacks FULL RELRO, check LDFLAGS.
spaln W: ELF file ('usr/bin/spaln') lacks FULL RELRO, check LDFLAGS.
```
currently distros are patching the `Makefile.in` with requisite flags for hardening the spaln binaries. this pull request, based on debian-med project's patches, adds the aforementioned flags to `Makefile.in' so the packagers can pass appropriate hardening option during build time. 
